### PR TITLE
bash scripts, distillation/fine-tuning scripts, data cleaning scripts and sanity check experiments for T5

### DIFF
--- a/bash_scripts/t5/README.md
+++ b/bash_scripts/t5/README.md
@@ -1,0 +1,1 @@
+You can use the same set of scripts for offline and online traininig on different tasks.

--- a/bash_scripts/t5/finetune_with_eval.sh
+++ b/bash_scripts/t5/finetune_with_eval.sh
@@ -1,0 +1,43 @@
+datapath=$1
+dataset_name=$2
+sample_source=$3
+kl=$4
+bsz=$5
+gradient_step=$6s
+
+python distill/train_mlm.py \
+    --student_model_path google/t5-efficient-small  \
+    --teacher_model_path google/flan-t5-xl \
+    --dataset_name ${dataset_name} \
+    --do_train \
+    --num_train_epochs 3 \
+    --per_device_train_batch_size ${bsz} \
+    --per_device_eval_batch_size 1 \
+    --gradient_accumulation_steps ${gradient_step} \
+    --evaluation_strategy "no" \
+    --save_strategy "steps" \
+    --save_steps 200 \
+    --save_total_limit 5 \
+    --learning_rate 2e-5 \
+    --weight_decay 0. \
+    --lr_scheduler_type "cosine" \
+    --warmup_ratio 0.03 \
+    --logging_steps 1 \
+    --source_max_length 1024 \
+    --train_target_max_length 512 \
+    --val_target_max_length 512 \
+    --test_target_max_length 512 \
+    --run_name t5_${dataset_name}_online_distill_${sample_source}_${kl} \
+    --output_dir $datapath/t5_${dataset_name}_finetune_${sample_source}_${kl}
+
+python distill/finetune_mlm.py \
+    --student_model_path $datapath/t5_${dataset_name}_finetune_${sample_source}_${kl}
+    --teacher_model_path google/t5-efficient-xl \
+    --dataset_name ${dataset_name} \
+    --do_predict \
+    --per_device_eval_batch_size 1 \
+    --logging_steps 1 \
+    --source_max_length 1024 \
+    --test_target_max_length 512 \
+    --run_name eval \
+    --output_dir $datapath/t5_${dataset_name}_finetune_evaluation_${sample_source}_${kl}

--- a/bash_scripts/t5/offline.sh
+++ b/bash_scripts/t5/offline.sh
@@ -1,0 +1,37 @@
+datapath=$1
+dataset_name=$2
+sample_source=$3
+kl=$4
+bsz=$5
+gradient_step=$6s
+
+python distill/train_mlm.py \
+    --student_model_path google/t5-efficient-small  \
+    --teacher_model_path google/flan-t5-xl \
+    --dataset_name ${dataset_name} \
+    --mode offline \
+    --sample_source ${sample_source} \
+    --kl_method forward \
+    --do_train \
+    --do_eval \
+    --fast_eval \
+    --num_train_epochs 3 \
+    --per_device_train_batch_size ${bsz} \
+    --per_device_eval_batch_size 1 \
+    --gradient_accumulation_steps ${gradient_step} \
+    --evaluation_strategy "steps" \
+    --eval_steps 50 \
+    --save_strategy "steps" \
+    --save_steps 200 \
+    --save_total_limit 5 \
+    --learning_rate 2e-5 \
+    --weight_decay 0. \
+    --lr_scheduler_type "cosine" \
+    --warmup_ratio 0.03 \
+    --logging_steps 1 \
+    --source_max_length 1024 \
+    --train_target_max_length 512 \
+    --val_target_max_length 512 \
+    --test_target_max_length 512 \
+    --run_name t5_${dataset_name}_online_distill_${sample_source}_${kl} \
+    --output_dir $datapath/t5_${dataset_name}_online_${sample_source}_${kl}

--- a/bash_scripts/t5/online.sh
+++ b/bash_scripts/t5/online.sh
@@ -1,0 +1,36 @@
+datapath=$1
+dataset_name=$2
+sample_source=$3
+kl=$4
+bsz=$5
+
+python distill/train_mlm.py \
+    --student_model_path google/t5-efficient-small  \
+    --teacher_model_path google/flan-t5-xl \
+    --dataset_name ${dataset_name} \
+    --max_propose_num 5 \
+    --mode online \
+    --sample_source ${sample_source} \
+    --all_token_mask True \
+    --do_train \
+    --num_train_epochs 1 \
+    --online_eval_interval 10 \
+    --online_update_interval ${bsz} \
+    --per_device_train_batch_size 1 \
+    --per_device_eval_batch_size 1 \
+    --gradient_accumulation_steps 1 \
+    --evaluation_strategy "no" \
+    --save_strategy "steps" \
+    --save_steps 200 \
+    --save_total_limit 5 \
+    --learning_rate 2e-5 \
+    --weight_decay 0. \
+    --warmup_ratio 0.03 \
+    --lr_scheduler_type "constant" \
+    --logging_steps 1 \
+    --source_max_length 1024 \
+    --train_target_max_length 512 \
+    --val_target_max_length 512 \
+    --test_target_max_length 512 \
+    --run_name t5_${dataset_name}_online_distill_${sample_source}_${kl} \
+    --output_dir $datapath/t5_${dataset_name}_online_${sample_source}_${kl}

--- a/bash_scripts/t5/sample_online_distill.sh
+++ b/bash_scripts/t5/sample_online_distill.sh
@@ -1,0 +1,60 @@
+datapath=$1
+dataset_name=$2
+sample_source=$3
+kl=$4
+
+python distill/train_mlm.py \
+    --student_model_path google/t5-efficient-small \
+    --teacher_model_path google/flan-t5-xl \
+    --dataset_name ${dataset_name} \
+    --max_propose_num 5 \
+    --output_dir $datapath/${dataset_name}_online_distill_${sample_source}_${kl} \
+    --do_train \
+    --num_train_epochs 0.1 \
+    --per_device_train_batch_size 1 \
+    --gradient_accumulation_steps 8 \
+    --evaluation_strategy "no" \
+    --save_strategy "steps" \
+    --save_steps 500 \
+    --save_total_limit 4 \
+    --learning_rate 2e-5 \
+    --weight_decay 0. \
+    --warmup_ratio 0.03 \
+    --lr_scheduler_type "cosine" \
+    --logging_steps 1 \
+    --source_max_length 1024 \
+    --test_target_max_length 512 \
+    --run_name t5_${dataset_name}_online_distill_${sample_source}_${kl} \
+    --mode offline \
+    --sample_source ${sample_source} \
+    --kl_method ${kl} \
+    --report_to none
+
+python3 distill/train_mlm.py \
+    --student_model_path $datapath/${dataset_name}_online_distill_${sample_source}_${kl} \
+    --teacher_model_path google/flan-t5-xl \
+    --dataset_name ${dataset_name} \
+    --max_propose_num 5 \
+    --output_dir $datapath/${dataset_name}_online_baseline_${sample_source}_${kl} \
+    --do_train \
+    --fast_eval \
+    --num_train_epochs 1 \
+    --per_device_train_batch_size 1 \
+    --gradient_accumulation_steps 1 \
+    --evaluation_strategy "no" \
+    --save_strategy "epoch" \
+    --learning_rate 1e-5 \
+    --weight_decay 0. \
+    --warmup_ratio 0. \
+    --lr_scheduler_type "constant" \
+    --logging_steps 1 \
+    --source_max_length 1024 \
+    --test_target_max_length 512 \
+    --run_name ${dataset_name}_online_baseline_${sample_source}_${kl} \
+    --mode online \
+    --sample_source ${sample_source} \
+    --kl_method ${kl} \
+    --online_eval_interval 1 \
+    --online_update_interval 100000 \
+    --logging_steps 1 \
+    --logging_nan_inf_filter true

--- a/data/generate_answer_t5.py
+++ b/data/generate_answer_t5.py
@@ -1,0 +1,46 @@
+import json
+from transformers import AutoTokenizer, LlamaForCausalLM, AutoModelForSeq2SeqLM
+from fastchat.model.model_adapter import get_conversation_template
+import torch
+from tqdm import tqdm
+import os
+
+import datasets
+
+import os
+
+from 
+
+model_path = "google/flan-t5-xl"
+model = AutoModelForSeq2SeqLM.from_pretrained(model_path).to("cuda")
+tokenizer = AutoTokenizer.from_pretrained(model_path)
+
+def generate_answer(prompt):
+    max_new_tokens = 128
+    inputs = tokenizer([prompt], return_tensors="pt").to(model.device)
+    generated = model.generate(**inputs, max_new_tokens=max_new_tokens)[0][1:-1]
+    generated_str = tokenizer.decode(generated)
+    return prompt, generated_str
+
+def main(dataset_name):
+    trainset = datasets.load_dataset(dataset_name,)['train']
+
+    def mapping(d):
+        question = d.pop('question')
+        prompt, answer = generate_answer(question)
+        
+        d['question'] = prompt
+        d['query'] = answer
+
+        return d
+    
+    trainset = trainset.map(mapping)
+    
+    path = "data/raw_data"
+    new_path = os.path.join(path, f"{dataset_name}_with_answer_t5.jsonl")
+    print(new_path)
+    trainset.to_json(new_path)
+
+if __name__ == "__main__":
+    dataset_name = 'spider'
+    main(dataset_name)

--- a/distill/data.py
+++ b/distill/data.py
@@ -1,0 +1,345 @@
+from typing import Tuple
+import torch
+import datasets
+from transformers import T5Tokenizer
+
+import json
+import os
+import re
+
+# GSM8K Dataset
+def read_jsonl(path: str):
+    with open(path) as fh:
+        return [json.loads(line) for line in fh.readlines() if line]
+
+
+def get_examples(split):
+    path = os.path.join("data/gsm8k/", f"{split}.jsonl")
+    examples = read_jsonl(path)
+
+    for ex in examples:
+        ex.update(question=ex["question"] + "\n")
+        ex.update(answer=ex["answer"] + "<|endoftext|>")
+
+    print(f"{len(examples)} {split} examples")
+    return examples
+
+
+ANS_RE = re.compile(r"#### (\-?[0-9\.\,]+)")
+INVALID_ANS = "[invalid]"
+
+
+def extract_answer(completion):
+    match = ANS_RE.search(completion)
+    if match:
+        match_str = match.group(1).strip()
+        match_str = match_str.replace(",", "")
+        return match_str
+    else:
+        return INVALID_ANS
+
+
+def is_correct(model_completion, gt_example):
+    gt_answer = extract_answer(gt_example["answer"])
+    assert gt_answer != INVALID_ANS
+    return extract_answer(model_completion) == gt_answer
+
+def preprocess_function_gsm8k(examples, tokenizer, args, train_args):
+    if train_args.debug:
+        inputs = examples["question"][:3]
+        targets = examples["answer"][:3]
+    else:
+        inputs = examples["question"]
+        targets = examples["answer"]
+    padding = 'max_length'
+    model_inputs = tokenizer(
+        inputs,
+        max_length=args.source_max_length,
+        padding=padding,
+        truncation=True,
+        return_tensors="pt",
+    )
+    # Tokenize targets with the `text_target` keyword argument
+    labels = tokenizer(
+        text_target=targets,
+        max_length=args.train_target_max_length,
+        padding=padding,
+        truncation=True,
+        return_tensors="pt", 
+    )
+
+    if padding == "max_length":
+                labels["input_ids"] = [
+                    [(l if l != tokenizer.pad_token_id else -100) for l in label] for label in labels["input_ids"]
+                ]
+
+    model_inputs["labels"] = labels["input_ids"]
+    model_inputs["decoder_attention_mask"] = labels["attention_mask"]
+    return model_inputs
+
+def load_gsm8k(train_path: str = "./data/train.jsonl",
+              test_path: str = "./data/test.jsonl"):
+    train_data = datasets.Dataset.from_list(read_jsonl(train_path))
+    test_data = datasets.Dataset.from_list(read_jsonl(test_path))
+    return train_data, test_data
+    
+def load_dataset_with_answers(train_path: str = "./data/train.jsonl"):
+    train_data = datasets.Dataset.from_list(read_jsonl(train_path))
+    return train_data
+
+class GSMDataset(torch.utils.data.Dataset):
+    def __init__(self, tokenizer, examples, loss_on_prefix=True):
+        self.examples = examples
+        self.qns = [ex["question"] for ex in self.examples]
+        self.ans = [ex["answer"] for ex in self.examples]
+        self.qns = tokenizer(self.qns, padding=False)
+        self.ans = tokenizer(self.ans, padding=False)
+        self.loss_on_prefix = loss_on_prefix
+        self.max_len = max(
+            [
+                len(self.qns["input_ids"][i]) + len(self.ans["input_ids"][i])
+                for i in range(len(self.examples))
+            ]
+        )
+        print(f"Max tokens: {self.max_len}")
+
+    def __len__(self):
+        return len(self.examples)
+
+    def __getitem__(self, idx):
+        qn_tokens = self.qns["input_ids"][idx]
+        ans_tokens = self.ans["input_ids"][idx]
+        pad_tokens = [0] * (self.max_len - len(qn_tokens) - len(ans_tokens))
+        tokens = qn_tokens + ans_tokens + pad_tokens
+        mask = (
+            ([int(self.loss_on_prefix)] * len(qn_tokens))
+            + ([1] * len(ans_tokens))
+            + ([0] * len(pad_tokens))
+        )
+        tokens = torch.tensor(tokens)
+        mask = torch.tensor(mask)
+        return dict(input_ids=tokens, attention_mask=mask)
+
+# SPIDER dataset
+def preprocess_function_spider(examples, tokenizer, args, train_args, prefix=""):
+    # prefix="Could you translate the following question into SQL. Please only generate SQL, don't include explanation in the answer."
+    if train_args.debug:
+        inputs = examples["question"][:3]
+        targets = examples["query"][:3]
+    else:
+        inputs = examples["question"]
+        inputs = [prefix + inp for inp in inputs]
+        targets = examples["query"]
+    padding = 'max_length'
+    model_inputs = tokenizer(
+        inputs,
+        max_length=args.source_max_length,
+        padding=padding,
+        truncation=True,
+        return_tensors="pt",
+    )
+    # Tokenize targets with the `text_target` keyword argument
+    labels = tokenizer(
+        text_target=targets,
+        max_length=args.train_target_max_length,
+        padding=padding,
+        truncation=True,
+        return_tensors="pt",
+    )
+
+    if padding == "max_length":
+                labels["input_ids"] = [
+                    [(l if l != tokenizer.pad_token_id else -100) for l in label] for label in labels["input_ids"]
+                ]
+
+    model_inputs["labels"] = labels["input_ids"]
+    model_inputs["decoder_attention_mask"] = labels["attention_mask"]
+    return model_inputs
+
+
+# WMT16 EN-DE dataset
+def preprocess_function_ende(examples, tokenizer, args, train_args, prefix="translate English to German: "):
+    if train_args.debug:
+        all_text = examples['translation'][:2]
+    else:
+        all_text = examples['translation']
+        
+    inputs = []
+    targets = []
+    for excerpt in all_text:
+        en_text = prefix + excerpt['en']
+        de_text = excerpt['de']
+
+        inputs.append(en_text)
+        targets.append(de_text)
+            
+    padding = 'max_length'
+    model_inputs = tokenizer(
+        inputs,
+        max_length=args.source_max_length,
+        padding=padding,
+        truncation=True,
+        return_tensors="pt",
+    )
+    # Tokenize targets with the `text_target` keyword argument
+    labels = tokenizer(
+        text_target=targets,
+        max_length=args.train_target_max_length,
+        padding=padding,
+        truncation=True,
+        return_tensors="pt",
+    )
+
+    if padding == "max_length":
+                labels["input_ids"] = [
+                    [(l if l != tokenizer.pad_token_id else -100) for l in label] for label in labels["input_ids"]
+                ]
+
+    model_inputs["labels"] = labels["input_ids"]
+    model_inputs["decoder_attention_mask"] = labels["attention_mask"]
+    return model_inputs
+
+#  Code-seach python dataset
+def preprocess_function_python(examples, tokenizer, args, train_args, prefix=""):
+    if train_args.debug:
+        inputs = examples["func_documentation_string"][:3]
+        targets = examples["func_code_string"][:3]
+    else:
+        inputs = examples["func_documentation_string"]
+        inputs = [prefix + inp for inp in inputs]
+        targets = examples["func_code_string"]
+    padding = 'max_length'
+    model_inputs = tokenizer(
+        inputs,
+        max_length=args.source_max_length,
+        padding=padding,
+        truncation=True,
+        return_tensors="pt",
+    )
+    # Tokenize targets with the `text_target` keyword argument
+    labels = tokenizer(
+        text_target=targets,
+        max_length=args.train_target_max_length,
+        padding=padding,
+        truncation=True,
+        return_tensors="pt",
+    )
+
+    if padding == "max_length":
+                labels["input_ids"] = [
+                    [(l if l != tokenizer.pad_token_id else -100) for l in label] for label in labels["input_ids"]
+                ]
+
+    model_inputs["labels"] = labels["input_ids"]
+    model_inputs["decoder_attention_mask"] = labels["attention_mask"]
+    return model_inputs
+
+# Finance-Alpaca dataset
+def preprocess_function_finance(examples, tokenizer, args, train_args, prefix=""):
+    if train_args.debug:
+        inputs = examples["instruction"][:3]
+        targets = examples["output"][:3]
+    else:
+        inputs = examples["instruction"]
+        inputs = [prefix + inp for inp in inputs]
+        targets = examples["output"]
+    padding = 'max_length'
+    model_inputs = tokenizer(
+        inputs,
+        max_length=args.source_max_length,
+        padding=padding,
+        truncation=True,
+        return_tensors="pt",
+    )
+    # Tokenize targets with the `text_target` keyword argument
+    labels = tokenizer(
+        text_target=targets,
+        max_length=args.train_target_max_length,
+        padding=padding,
+        truncation=True,
+        return_tensors="pt",
+    )
+
+    if padding == "max_length":
+                labels["input_ids"] = [
+                    [(l if l != tokenizer.pad_token_id else -100) for l in label] for label in labels["input_ids"]
+                ]
+
+    model_inputs["labels"] = labels["input_ids"]
+    model_inputs["decoder_attention_mask"] = labels["attention_mask"]
+    return model_inputs
+
+# code-search python dataset
+def preprocess_function_python(examples, tokenizer, args, train_args, prefix=""):
+    if train_args.debug:
+        inputs = examples["func_documentation_string"][:3]
+        targets = examples["func_code_string"][:3]
+    else:
+        inputs = examples["func_documentation_string"]
+        inputs = [prefix + inp for inp in inputs]
+        targets = examples["func_code_string"]
+    padding = 'max_length'
+    model_inputs = tokenizer(
+        inputs,
+        max_length=args.source_max_length,
+        padding=padding,
+        truncation=True,
+        return_tensors="pt",
+    )
+    # Tokenize targets with the `text_target` keyword argument
+    labels = tokenizer(
+        text_target=targets,
+        max_length=args.train_target_max_length,
+        padding=padding,
+        truncation=True,
+        return_tensors="pt",
+    )
+
+    if padding == "max_length":
+                labels["input_ids"] = [
+                    [(l if l != tokenizer.pad_token_id else -100) for l in label] for label in labels["input_ids"]
+                ]
+
+    model_inputs["labels"] = labels["input_ids"]
+    model_inputs["decoder_attention_mask"] = labels["attention_mask"]
+    return model_inputs
+
+# genric preprocess function, generally applicable to summarization tasks
+def preprocess_function_generic(examples, tokenizer, args, prefix=""):
+  # remove pairs where at least one record is None
+
+  # Get the column names for input/target.
+  keys = list(examples.keys())
+  #print(f'keys: {keys}')
+  text_column = keys[0]
+  summary_column = keys[1]
+
+  # Temporarily set max_target_length for training.
+  max_target_length = args.train_target_max_length
+  # default set padding to "max_length"
+  padding = "max_length"
+
+  # remove pairs where at least one record is None
+  inputs, targets = [], []
+  for i in range(len(examples[text_column])):
+      if examples[text_column][i] and examples[summary_column][i]:
+          prompt = prefix + examples[text_column][i]
+          inputs.append(prompt)
+          targets.append(examples[summary_column][i])
+
+  print(f'dataset length: {len(inputs)}')
+  model_inputs = tokenizer(inputs, max_length=args.source_max_length, padding=padding, truncation=True, return_tensors="pt", )
+
+  # Tokenize targets with the `text_target` keyword argument
+  labels = tokenizer(text_target=targets, max_length=max_target_length, padding=padding, truncation=True, return_tensors="pt", )
+
+  # If we are padding here, replace all tokenizer.pad_token_id in the labels by -100 when we want to ignore
+  # padding in the loss.
+  if padding == "max_length" and args.ignore_pad_token_for_loss:
+      labels["input_ids"] = [
+          [(l if l != tokenizer.pad_token_id else -100) for l in label] for label in labels["input_ids"]
+      ]
+
+  model_inputs["labels"] = labels["input_ids"]
+  model_inputs["decoder_attention_mask"] = labels["attention_mask"]
+  return model_inputs

--- a/distill/experiment/compare_model_t5.py
+++ b/distill/experiment/compare_model_t5.py
@@ -1,0 +1,146 @@
+import os
+import sys
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(parent_dir)
+
+import datasets
+from functools import partial
+
+import numpy as np
+
+import argparse
+import json
+import pickle
+import torch
+from transformers import AutoTokenizer, AutoConfig, AutoModelForSeq2SeqLM
+from specInfer.generator import Generator
+from specInfer.generator_seq2seq import Seq2SeqGenerator
+from train import LazySupervisedDataset
+
+from distill.data import preprocess_function_spider
+
+def load_model(model_path):
+    config = AutoConfig.from_pretrained(model_path)
+    model = AutoModelForSeq2SeqLM.from_pretrained(
+        model_path, config=config).cuda()
+    return model
+
+def main(student_model_path,
+         teacher_model_path,
+         max_propose_num,
+         dataset):
+    tokenizer = AutoTokenizer.from_pretrained(teacher_model_path)
+    tokenizer.pad_token = tokenizer.unk_token
+    teacher_model = load_model(teacher_model_path)
+    student_model = load_model(student_model_path)
+    generator = Seq2SeqGenerator(student_model, teacher_model,
+                          tokenizer, max_propose_num)
+
+    raw_datasets = datasets.load_dataset(
+            dataset,
+    )
+    partial_preprocess_function = partial(
+        preprocess_function_spider,
+        tokenizer=tokenizer,
+        max_source_length=512, max_target_length=512
+    )
+    eval_dataset = raw_datasets["validation"]
+    eval_dataset = eval_dataset.map(
+        partial_preprocess_function,
+        batched=True,
+        remove_columns=eval_dataset.column_names,
+        desc="Running tokenizer on eval dataset",
+    )
+
+    i = 0
+    correctness = 0
+    stats = torch.zeros(32000, dtype=torch.long, device='cuda')
+    alpha, sample_steps = 0, 0
+    for d in eval_dataset:
+        max_tokens = 128
+
+        input_ids = torch.Tensor(d["input_ids"]).long().reshape(1, -1).to(model.device)
+        attention_mask = torch.Tensor(d["attention_mask"]).long().reshape(1, -1).to(model.device)
+
+        output = generator.generate(input_ids, attention_mask, max_tokens, temperature=0.01)
+        correct_tokens = output.correct_tokens.squeeze(0)
+        print(5097 in correct_tokens.tolist())
+        stats[correct_tokens] = stats[correct_tokens] + 1
+        if i % 10 == 0:
+            print(f"{i}/{len(eval_dataset)}")
+        print("===================================")
+        print('Question:')
+        print(tokenizer.decode(d["input_ids"], skip_special_tokens=True))
+        print('Answer:')
+        print(output.output)
+        print(correct_tokens.shape)
+        print(output.propose_steps, correct_tokens.shape[-1]/output.propose_steps)
+        print("===================================")
+        correctness += output.correct_tokens.shape[-1]/output.propose_steps
+        alpha += output.alpha_sum
+        sample_steps += output.sample_steps
+        i += 1
+        if i == 5:
+            break
+    print(i, correctness / i, alpha / sample_steps)
+
+def model_generate(model_path, dataset):
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    tokenizer.pad_token = tokenizer.unk_token
+    model = load_model(model_path)
+    param_sum = 0
+    for param in model.parameters():
+        param_sum += param.data.sum()
+    print(f"Param Sum: {param_sum}")
+    
+    raw_datasets = datasets.load_dataset(
+            dataset,
+    )
+    partial_preprocess_function = partial(
+        preprocess_function_spider,
+        tokenizer=tokenizer,
+        max_source_length=1024, max_target_length=1024
+    )
+    eval_dataset = raw_datasets["validation"]
+    eval_dataset = eval_dataset.map(
+        partial_preprocess_function,
+        batched=True,
+        remove_columns=eval_dataset.column_names,
+        desc="Running tokenizer on eval dataset",
+    )
+
+    i = 0
+    for d in eval_dataset:
+        max_tokens = 100
+        input_ids = torch.Tensor(d["input_ids"]).long().reshape(1, -1).to(model.device)
+        attention_mask = torch.Tensor(d["attention_mask"]).long().reshape(1, -1).to(model.device)
+        generated = model.generate(input_ids, attention_mask,
+                                   max_new_tokens=max_tokens, decoder_start_token_id=model.config.pad_token_id)[
+            0]
+        print(f"Prompt: {tokenizer.decode(input_ids[0])}")
+        print(f"Answer: {tokenizer.decode(generated)}")
+        print("----------------------------------")
+        i += 1
+        if i == 5:
+            break
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--student", type=str,
+                        help="student model path",
+                        default="google/t5-efficient-small")
+    parser.add_argument("--teacher", type=str,
+                        help="teacher model path",
+                        default="google/t5-efficient-xl")
+    parser.add_argument("--dataset", type=str,
+                        help="data",
+                        default="spider")
+    parser.add_argument("--max_propose_num", type=int,
+                        help="number of proposed tokens",
+                        default=5)
+
+    args = parser.parse_args()
+    main(args.student, args.teacher, args.max_propose_num, args.dataset)
+    model_generate(args.student, args.dataset)

--- a/distill/experiment/test_t5.py
+++ b/distill/experiment/test_t5.py
@@ -1,0 +1,65 @@
+import os
+import sys
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(parent_dir)
+
+from specInfer.generator_seq2seq import Seq2SeqGenerator
+from specInfer.common import sychronize_time
+from transformers import AutoTokenizer, AutoModelForSeq2SeqLM, T5ForConditionalGeneration
+import torch
+
+
+
+model_path = "google/flan-t5-xl"
+model = T5ForConditionalGeneration.from_pretrained(model_path).to('cuda')
+tokenizer = AutoTokenizer.from_pretrained(model_path)
+small_model = T5ForConditionalGeneration.from_pretrained("google/flan-t5-small").to(model.device)
+
+text_summary = """Q: summarize the following text in one or two sentences.
+Script: Mao Zedong, Wade-Giles romanization Mao Tse-tung, (born December 26, 1893, Shaoshan, Hunan province, China—died September 9, 1976, Beijing), principal Chinese Marxist theorist, soldier, and statesman who led his country’s communist revolution. Mao was the leader of the Chinese Communist Party (CCP) from 1935 until his death, and he was chairman (chief of state) of the People’s Republic of China from 1949 to 1959 and chairman of the party also until his death.
+When China emerged from a half century of revolution as the world’s most populous country and launched itself on a path of economic development and social change, Mao Zedong occupied a critical place in the story of the country’s resurgence. To be sure, he did not play a dominant role throughout the whole struggle. In the early years of the CCP, he was a secondary figure, though by no means a negligible one, and even after the 1940s (except perhaps during the Cultural Revolution) the crucial decisions were not his alone. Nevertheless, looking at the whole period from the foundation of the CCP in 1921 to Mao’s death in 1976, one can fairly regard Mao Zedong as the principal architect of the new China."""
+
+text_summary_cnndm = """Q: summarize the following text in one or two sentences.
+Script: LONDON, England (Reuters) -- Harry Potter star Daniel Radcliffe gains access to a reported £20 million ($41.1 million) fortune as he turns 18 on Monday, but he insists the money won't cast a spell on him. Daniel Radcliffe as Harry Potter in "Harry Potter and the Order of the Phoenix" To the disappointment of gossip columnists around the world, the young actor says he has no plans to fritter his cash away on fast cars, drink and celebrity parties. "I don't plan to be one of those people who, as soon as they turn 18, suddenly buy themselves a massive sports car collection or something similar," he told an Australian interviewer earlier this month. "I don't think I'll be particularly extravagant. "The things I like buying are things that cost about 10 pounds -- books and CDs and DVDs." At 18, Radcliffe will be able to gamble in a casino, buy a drink in a pub or see the horror film "Hostel: Part II," currently six places below his number one movie on the UK box office chart. Details of how he'll mark his landmark birthday are under wraps. His agent and publicist had no comment on his plans. "I'll definitely have some sort of party," he said in an interview. "Hopefully none of you will be reading about it." Radcliffe's earnings from the first five Potter films have been held in a trust fund which he has not been able to touch. Despite his growing fame and riches, the actor says he is keeping his feet firmly on the ground. "People are always looking to say 'kid star goes off the rails,'" he told reporters last month. "But I try very hard not to go that way because it would be too easy for them." His latest outing as the boy wizard in "Harry Potter and the Order of the Phoenix" is breaking records on both sides of the Atlantic and he will reprise the role in the last two films. Watch I-Reporter give her review of Potter's latest » . There is life beyond Potter, however. The Londoner has filmed a TV movie called "My Boy Jack," about author Rudyard Kipling and his son, due for release later this year. He will also appear in "December Boys," an Australian film about four boys who escape an orphanage. Earlier this year, he made his stage debut playing a tortured teenager in Peter Shaffer's "Equus." Meanwhile, he is braced for even closer media scrutiny now that he's legally an adult: "I just think I'm going to be more sort of fair game," he told Reuters. E-mail to a friend . Copyright 2007 Reuters. All rights reserved.This material may not be published, broadcast, rewritten, or redistributed.
+A: 
+"""
+
+text_sql = """Could you translate the following question into SQL. Please only generate SQL, don't include explanation in the answer. How many singers do we have?"""
+
+text_gsm8k = """Natalia sold clips to 48 of her friends in April, and then she sold half as many clips in May. How many clips did Natalia sell altogether in April and May?"""
+
+text_ende = """Translate English to German: I declare resumed the session of the European Parliament adjourned on Friday 17 December 1999, and I would like once again to wish you a happy new year in the hope that you enjoyed a pleasant festive period."""
+
+inputs = tokenizer([text_sql], return_tensors="pt").to(model.device)
+#print("Input:")
+#print(inputs)
+input_ids = inputs.input_ids
+attention_mask = inputs.attention_mask
+max_new_tokens = 200
+
+# warmup
+ref_generated = model.generate(**inputs, max_new_tokens=max_new_tokens)[0]
+
+###################################### Reference Generation ##############################
+start = sychronize_time()
+ref_generated = model.generate(**inputs, max_new_tokens=max_new_tokens)[0]
+print(f"Reference Time: {sychronize_time() - start}")
+# print(tokenizer.decode(ref_generated), end="\n\n")
+print('Reference output: {}'.format(ref_generated))
+summary = tokenizer.decode(ref_generated, skip_special_tokens=True)
+print("Reference Answer:")
+print(f"{summary}")
+
+
+###################################### Speculative Decoding ##############################
+propose_num = 4
+generator = Seq2SeqGenerator(small_model, model, tokenizer, propose_num)
+start = sychronize_time()
+output = generator.generate(input_ids, attention_mask, max_new_tokens)
+
+print("Our generator output:")
+print(output.output[0])
+print(f"Speculative Decoding Time: {sychronize_time() - start}")
+print(f"alpha: {output.alpha_sum / output.sample_steps}, ",
+      f"avg # of correct tokens: {output.correct_tokens.shape[-1] / output.propose_steps}")

--- a/distill/finetune_mlm.py
+++ b/distill/finetune_mlm.py
@@ -1,0 +1,392 @@
+# This code is based on tatsu-lab/stanford_alpaca. Below is the original copyright:
+#
+#    Copyright 2023 Rohan Taori, Ishaan Gulrajani, Tianyi Zhang, Yann Dubois, Xuechen Li
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from dataclasses import dataclass, field
+import json
+import math
+import pathlib
+from typing import Dict, Optional, Sequence
+
+import wandb
+
+import random
+
+import os
+
+import datasets
+import evaluate
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+import transformers
+from transformers import Trainer
+from transformers.trainer_pt_utils import LabelSmoother
+
+from fastchat.conversation import SeparatorStyle
+from fastchat.model.model_adapter import get_conversation_template
+
+from functools import partial
+
+# local import
+from distill_trainer import DistillTrainer, DistillTrainerCallback
+from distill_trainer_seq2seq import Seq2SeqDistillTrainer, Seq2SeqDistillTrainerCallback
+from summarization_data import Xsum_Dataset, Wikihow_Dataset, preprocess_function_generic
+from qa_data import load_gsm8k, load_gsm8k_with_answers, preprocess_function_gsm8k, preprocess_function_spider, load_spider_with_answers, preprocess_function_ende, preprocess_function_finance, load_finance_with_answers, preprocess_function_python, load_python_with_answers
+
+IGNORE_TOKEN_ID = LabelSmoother.ignore_index
+
+
+@dataclass
+class ModelArguments:
+    student_model_path: Optional[str] = field(
+        default="facebook/opt-125m",  metadata={"help": "Path to student model"})
+    teacher_model_path: str = field(
+        default=None, metadata={"help": "Path to teacher model"})
+
+
+@dataclass
+class DataArguments:
+    dataset_name: str = field(
+        default=None, metadata={"help": "Dataset's name."}
+    )
+    dataset_config_name: Optional[str] = field(
+        default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
+    )
+    metric: str = field(
+        default='rouge', metadata={"help": "Metric to use for evaluation."}
+    )
+    source_max_length: int = field(
+        default=1024,
+        metadata={
+            "help": "Maximum sequence length for the source. Sequences will be right padded (and possibly truncated)."
+        },
+    )
+    train_target_max_length: int = field(
+        default=64,
+        metadata={
+            "help": "Maximum sequence length for the target during training. Sequences will be right padded."
+        },
+    )
+    val_target_max_length: int = field(
+        default=128,
+        metadata={
+            "help": "Maximum sequence length for the target during validation. Sequences will be right padded."
+        },
+    )
+    test_target_max_length: int = field(
+        default=128,
+        metadata={
+            "help": "Maximum sequence length for the target during testing. Sequences will be right padded."
+        },
+    )
+    max_train_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of training examples to this "
+                "value if set."
+            )
+        },
+    )
+    max_eval_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of evaluation examples to this "
+                "value if set."
+            )
+        },
+    )
+    max_predict_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of prediction examples to this "
+                "value if set."
+            )
+        },
+    )
+    ignore_pad_token_for_loss: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether to ignore the tokens corresponding to padded labels in the loss computation or not."
+        },
+    )
+    num_beams: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Number of beams to use for evaluation. This argument will be passed to ``model.generate``, "
+                "which is used during ``evaluate`` and ``predict``."
+            )
+        },
+    )
+    source_prefix: Optional[str] = field(
+        default="", metadata={"help": "A prefix to add before every source text (useful for T5 models)."}
+    )
+    fast_eval: bool = field(
+        default=True,
+        metadata={"help": "Fast evaluation strategy for logging."}
+    )
+
+
+@dataclass
+class Seq2SeqTrainingArguments(transformers.Seq2SeqTrainingArguments):
+    cache_dir: Optional[str] = field(default=None)
+    optim: str = field(default="adamw_torch")
+    max_propose_num: int = field(
+        default=5,
+        metadata={
+            "help": "gamma, number of tokens the student model proposes for each step."
+        }
+    )
+    mode: str = field(
+        default="offline",
+        metadata={
+            "help": "online mode or offline mode"
+        }
+    )
+    online_eval_interval: int = field(
+        default=10,
+        metadata={
+            "help": "evaluation interval for online training"
+        }
+    )
+    online_update_interval: int = field(
+        default=1,
+        metadata={
+            "help": "parameter update interval for online training"
+        }
+    )
+    sample_source: str = field(
+        default="student",
+        metadata = {
+            "choices" : ["student", "teacher", "mix_request", "mix_token"]
+        }
+    )
+    kl_method: str = field(
+        default="forward",
+        metadata = {
+            "choices" : ["forward", "reverse", "jsd"]
+        }
+    )
+
+local_rank = None
+
+
+def rank0_print(*args):
+    if local_rank == 0:
+        print(*args)
+
+
+def safe_save_model_for_hf_trainer(trainer: transformers.Trainer, output_dir: str):
+    """Collects the state dict and dump to disk."""
+    state_dict = trainer.model.state_dict()
+    if trainer.args.should_save:
+        cpu_state_dict = {key: value.cpu()
+                          for key, value in state_dict.items()}
+        del state_dict
+        trainer._save(output_dir, state_dict=cpu_state_dict)  # noqa
+
+
+def train():
+    global local_rank
+    
+    parser = transformers.HfArgumentParser(
+        (ModelArguments, DataArguments, Seq2SeqTrainingArguments)
+    )
+    model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+    local_rank = training_args.local_rank
+
+    # Set RoPE scaling factor
+    config = transformers.AutoConfig.from_pretrained(
+        model_args.student_model_path,
+        cache_dir=training_args.cache_dir,
+    )
+    orig_ctx_len = getattr(config, "max_position_embeddings", None)
+    if orig_ctx_len and data_args.source_max_length > orig_ctx_len:
+        scaling_factor = float(
+            math.ceil(data_args.source_max_length / orig_ctx_len))
+        config.rope_scaling = {"type": "linear", "factor": scaling_factor}
+    config.use_cache = False
+
+    # Load model and tokenizer
+    # student model
+    model = transformers.AutoModelForSeq2SeqLM.from_pretrained(
+        model_args.student_model_path,
+        config=config,
+        cache_dir=training_args.cache_dir,
+    )
+    # # train from scratch
+    # model = transformers.LlamaForCausalLM(config)
+
+    # teacher model
+    teacher_config = transformers.AutoConfig.from_pretrained(
+        model_args.teacher_model_path,
+        cache_dir=training_args.cache_dir,
+    )
+    teacher_model = transformers.AutoModelForSeq2SeqLM.from_pretrained(
+        model_args.teacher_model_path,
+        config=teacher_config
+    )
+    teacher_model.cuda()
+
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        model_args.teacher_model_path,
+    )
+    tokenizer.pad_token = tokenizer.unk_token
+
+    training_args.max_source_length = data_args.source_max_length
+    training_args.max_target_length = data_args.train_target_max_length
+     # Load data
+    train_dataset, eval_dataset, predict_dataset = load_dataset(data_args, training_args, tokenizer)
+
+    # We resize the embeddings only when necessary to avoid index errors. If you are creating a model from scratch
+    # on a small vocab and want a smaller embedding size, remove this test.
+    embedding_size = model.get_input_embeddings().weight.shape[0]
+    if len(tokenizer) > embedding_size:
+        model.resize_token_embeddings(len(tokenizer))
+
+    if model.config.decoder_start_token_id is None:
+        raise ValueError("Make sure that `config.decoder_start_token_id` is correctly defined")
+
+    if (
+        hasattr(model.config, "max_position_embeddings")
+        and model.config.max_position_embeddings < data_args.source_max_length
+    ):
+        if model_args.resize_position_embeddings is None:
+            model.resize_position_embeddings(data_args.msource_max_length)
+        elif model_args.resize_position_embeddings:
+            model.resize_position_embeddings(data_args.source_max_length)
+        else:
+            raise ValueError(
+                f"`--source_max_length` is set to {data_args.source_max_length}, but the model only has"
+                f" {model.config.max_position_embeddings} position encodings. Consider either reducing"
+                f" `--source_max_length` to {model.config.max_position_embeddings} or to automatically resize the"
+                " model's position encodings by passing `--resize_position_embeddings`."
+            )
+
+    training_args.generation_num_beams = (
+        data_args.num_beams if data_args.num_beams is not None else training_args.generation_num_beams
+    )
+    # Data collator
+    label_pad_token_id = -100 if data_args.ignore_pad_token_for_loss else tokenizer.pad_token_id
+    data_collator = transformers.DataCollatorForSeq2Seq(
+        tokenizer,
+        model=model,
+        label_pad_token_id=label_pad_token_id,
+        pad_to_multiple_of=8 if training_args.fp16 else None,
+    )
+
+    metric = evaluate.load("rouge")
+    
+    def postprocess_text(preds, labels):
+        preds = [pred.strip() for pred in preds]
+        labels = [label.strip() for label in labels]
+
+        # rougeLSum expects newline after each sentence
+        preds = ["\n".join(nltk.sent_tokenize(pred)) for pred in preds]
+        labels = ["\n".join(nltk.sent_tokenize(label)) for label in labels]
+
+        return preds, labels
+
+    def compute_metrics(eval_preds):
+        preds, labels = eval_preds
+        if isinstance(preds, tuple):
+            preds = preds[0]
+        # Replace -100s used for padding as we can't decode them
+        preds = np.where(preds != -100, preds, tokenizer.pad_token_id)
+        decoded_preds = tokenizer.batch_decode(preds, skip_special_tokens=True)
+        labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+        decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+
+        # Some simple post-processing
+        decoded_preds, decoded_labels = postprocess_text(decoded_preds, decoded_labels)
+
+        result = metric.compute(predictions=decoded_preds, references=decoded_labels, use_stemmer=True)
+        result = {k: round(v * 100, 4) for k, v in result.items()}
+        prediction_lens = [np.count_nonzero(pred != tokenizer.pad_token_id) for pred in preds]
+        result["gen_len"] = np.mean(prediction_lens)
+        return result
+    
+    trainer = Seq2SeqDistillTrainer(
+            model=model, 
+            teacher_model=teacher_model,
+            tokenizer=tokenizer, 
+            train_dataset=train_dataset if training_args.do_train else None,
+            eval_dataset=eval_dataset if training_args.do_eval else None,
+            data_collator=data_collator,
+            compute_metrics=compute_metrics if training_args.predict_with_generate else None,
+            propose_num=training_args.max_propose_num,
+            args=training_args,
+        )
+    trainer.add_callback(Seq2SeqDistillTrainerCallback)
+    # ---------------------------------------------------------------------------------------------------------------
+
+    if training_args.do_train:
+        if list(pathlib.Path(training_args.output_dir).glob("checkpoint-*")):
+            train_result = trainer.train(resume_from_checkpoint=True)
+        else:
+            train_result = trainer.train()
+        trainer.save_model()
+        metrics = train_result.metrics
+        max_train_samples = (
+            data_args.max_train_samples if data_args.max_train_samples is not None else len(train_dataset)
+        )
+        metrics["train_samples"] = min(max_train_samples, len(train_dataset))
+
+        trainer.log_metrics("train", metrics)
+        trainer.save_metrics("train", metrics)
+        model.config.use_cache = True
+        trainer.save_state()
+
+    # Evaluation
+    results = {}
+    if training_args.do_eval:
+        if isinstance(eval_dataset, dict):
+            metrics = {}
+            for eval_ds_name, eval_ds in eval_dataset.items():
+                dataset_metrics = trainer.evaluate(eval_dataset=eval_ds, metric_key_prefix=f"eval_{eval_ds_name}")
+                metrics.update(dataset_metrics)
+        else:
+            metrics = trainer.evaluate(metric_key_prefix="eval")
+        max_eval_samples = data_args.max_eval_samples if data_args.max_eval_samples is not None else len(eval_dataset)
+        metrics["eval_samples"] = min(max_eval_samples, len(eval_dataset))
+
+        trainer.log_metrics("eval", metrics)
+        trainer.save_metrics("eval", metrics)
+
+    # Testing
+    if training_args.do_predict:
+
+        predict_results = trainer.predict(predict_dataset, metric_key_prefix="predict")
+        metrics = predict_results.metrics
+        max_predict_samples = (
+            data_args.max_predict_samples if data_args.max_predict_samples is not None else len(predict_dataset)
+        )
+        metrics["predict_samples"] = min(max_predict_samples, len(predict_dataset))
+
+        trainer.log_metrics("predict", metrics)
+        trainer.save_metrics("predict", metrics)
+    
+    
+    safe_save_model_for_hf_trainer(
+        trainer=trainer, output_dir=training_args.output_dir)
+
+
+if __name__ == "__main__":
+    train()

--- a/distill/load_dataset.py
+++ b/distill/load_dataset.py
@@ -1,0 +1,202 @@
+from dataclasses import dataclass, field
+import json
+import math
+import pathlib
+from typing import Dict, Optional, Sequence
+
+import wandb
+
+import random
+
+import os
+
+import datasets
+import evaluate
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+import transformers
+from transformers import Trainer
+from transformers.trainer_pt_utils import LabelSmoother
+
+from fastchat.conversation import SeparatorStyle
+from fastchat.model.model_adapter import get_conversation_template
+
+from functools import partial
+
+# local import
+from distill_trainer import DistillTrainer, DistillTrainerCallback
+from distill_trainer_seq2seq import Seq2SeqDistillTrainer, Seq2SeqDistillTrainerCallback
+from data import load_gsm8k, preprocess_function_gsm8k, preprocess_function_spider, preprocess_function_ende, preprocess_function_finance, preprocess_function_python, preprocess_function_generic, load_dataset_with_answers
+
+IGNORE_TOKEN_ID = LabelSmoother.ignore_index
+
+
+def load_dataset(data_args, training_args, tokenizer):
+    train_dataset = None
+    eval_dataset = None
+    predict_dataset = None
+
+    global preprocess_function_gsm8k
+    global preprocess_function_spider
+    global load_dataset_with_answers
+    
+    if data_args.dataset_name == 'gsm8k':
+        global load_gsm8k
+        preprocess_function = preprocess_function_gsm8k
+        train_dataset, predict_dataset = load_gsm8k(train_path=os.path.join(os.getcwd(), 'data/gsm8k/train.jsonl'), test_path=os.path.join(os.getcwd(), 'data/gsm8k/test.jsonl'))
+    elif data_args.dataset_name == 'wmt16' and data_args.dataset_config_name == 'de-en':
+        global preprocess_function_ende
+        # support english to german only
+        preprocess_function = preprocess_function_ende
+        raw_datasets = datasets.load_dataset(
+            data_args.dataset_name,
+            data_args.dataset_config_name,
+        )
+    elif data_args.dataset_name == 'spider':
+        preprocess_function = preprocess_function_spider
+        raw_datasets = datasets.load_dataset(
+            data_args.dataset_name,
+            data_args.dataset_config_name,
+        )
+    elif data_args.dataset_name == 'gsm8k_with_answers':
+        preprocess_function = preprocess_function_gsm8k
+        train_dataset = load_dataset_with_answers(train_path=os.path.join(os.getcwd(), 'data/gsm8k_with_answer_t5.jsonl'))
+    elif data_args.dataset_name == 'spider_with_answers':
+        preprocess_function = preprocess_function_spider
+        train_dataset = load_dataset_with_answers(train_path=os.path.join(os.getcwd(), 'data/spider_with_answer_t5.jsonl'))
+    elif data_args.dataset_name == 'finance_with_answers':
+        global preprocess_function_finance
+        preprocess_function = preprocess_function_finance
+        train_dataset = load_dataset_with_answers(train_path=os.path.join(os.getcwd(), 'data/gbharti/finance-alpaca_with_answer_t5.jsonl'))
+    elif data_args.dataset_name == 'python_with_answers':
+        global preprocess_function_python
+        preprocess_function = preprocess_function_python
+        train_dataset = load_dataset_with_answers(train_path=os.path.join(os.getcwd(), 'data/code_search_net_with_answer_t5.jsonl'))
+    else:
+        # generic data preprocessing
+        global preprocess_function_generic
+        preprocess_function = preprocess_function_generic
+        raw_datasets = datasets.load_dataset(
+            data_args.dataset_name,
+            data_args.dataset_config_name,
+        )
+
+    prefix = data_args.source_prefix if data_args.source_prefix is not None else ""
+    print(f'prefix: {prefix}')
+
+    if 'with_answers' in data_args.dataset_name:
+        partial_preprocess_function = partial(
+            preprocess_function,
+            tokenizer=tokenizer,
+            args=data_args,
+            train_args=training_args
+        )
+    else:
+        partial_preprocess_function = partial(
+            preprocess_function,
+            tokenizer=tokenizer,
+            args=data_args,
+            prefix=prefix
+        )
+
+    # preprocess datasets that don't have validation sets
+    require_val_tasks = [
+        'gsm8k',
+        'gsm8k_with_answers',
+        'spider_with_answers',
+        'python_with_answers',
+        'finance_with_answers',
+    ]
+    if data_args.dataset_name in require_val_tasks and training_args.do_train and training_args.do_eval:
+        # take 1/5 of training set to be evaluation dataset
+        train_indices = range(len(train_dataset)//5 * 4)
+        eval_indices = range(len(train_dataset)//5 * 4, len(train_dataset))
+
+        eval_dataset = datasets.Dataset.from_dict(train_dataset[eval_indices])  
+        train_dataset = datasets.Dataset.from_dict(train_dataset[train_indices])
+
+        print('train dataset size: {}'.format(len(train_dataset)))
+        print('eval dataset size: {}'.format(len(eval_dataset)))
+
+    num_proc = 16
+    # Preprocessing the datasets for summarization tasks.
+    # We need to tokenize inputs and targets.
+    if training_args.do_train:
+        if not train_dataset:
+            train_dataset = raw_datasets["train"]
+        
+        if data_args.dataset_name == 'wmt16':
+            # handle special case: WMT16 dataset is too large and too slow to tokenize, not the entire set is needed
+            train_dataset = train_dataset.select(range(len(train_dataset) // 2))
+
+        print('train dataset size: {}'.format(len(train_dataset)))
+
+        if data_args.max_train_samples is not None:
+            max_train_samples = min(len(train_dataset), data_args.max_train_samples)
+            train_dataset = train_dataset.select(range(max_train_samples))
+        with training_args.main_process_first(desc="train dataset map pre-processing"):
+            train_dataset = train_dataset.map(
+                partial_preprocess_function,
+                num_proc=num_proc,
+                batched=True,
+                remove_columns=train_dataset.column_names,
+                desc="Running tokenizer on train dataset",
+            )
+    if training_args.do_eval:
+        if not eval_dataset:
+            eval_dataset = raw_datasets["validation"]
+        print('eval dataset size: {}'.format(len(eval_dataset)))
+        max_target_length = data_args.val_target_max_length
+        if data_args.max_eval_samples is not None:
+            max_eval_samples = min(len(eval_dataset), data_args.max_eval_samples)
+            eval_dataset = eval_dataset.select(range(max_eval_samples))
+        with training_args.main_process_first(desc="train dataset map pre-processing"):
+            eval_dataset = eval_dataset.map(
+                partial_preprocess_function,
+                num_proc=num_proc,
+                batched=True,
+                remove_columns=eval_dataset.column_names,
+                desc="Running tokenizer on eval dataset",
+            )
+    if training_args.do_predict:
+        if not predict_dataset:
+            predict_dataset = raw_datasets["test"]
+        print('test dataset size: {}'.format(len(predict_dataset)))
+        max_target_length = data_args.test_target_max_length
+        if data_args.max_predict_samples is not None:
+            max_predict_samples = min(len(predict_dataset), data_args.max_predict_samples)
+            predict_dataset = predict_dataset.select(range(max_predict_samples))
+        with training_args.main_process_first(desc="train dataset map pre-processing"):
+            predict_dataset = predict_dataset.map(
+                partial_preprocess_function,
+                num_proc=num_proc,
+                batched=True,
+                remove_columns=predict_dataset.column_names,
+                desc="Running tokenizer on test dataset",
+            )  
+
+    # data partitioning for fast evaluation model (only a subset of the validation set is used)
+    if data_args.fast_eval:  
+        if training_args.do_eval:
+            if len(eval_dataset) < 200:
+                eval_length = len(eval_dataset)
+            else:
+                eval_length = 200
+
+            eval_random_indices = random.sample(range(len(eval_dataset)), eval_length)
+            eval_dataset = datasets.Dataset.from_dict(eval_dataset[eval_random_indices])
+            print('fast eval... updated eval dataset size: {}'.format(len(eval_dataset)))
+
+        if training_args.do_predict:
+            if len(predict_dataset) < 200:
+                eval_length = len(predict_dataset)
+            else:
+                eval_length = 200
+            
+            predict_random_indices = random.sample(range(len(predict_dataset)), eval_length)
+            predict_dataset = datasets.Dataset.from_dict(predict_dataset[predict_random_indices])
+            print('fast eval... updated test dataset size: {}'.format(len(predict_dataset)))
+    
+    return train_dataset, eval_dataset, predict_dataset

--- a/distill/train_mlm.py
+++ b/distill/train_mlm.py
@@ -1,0 +1,398 @@
+# This code is based on tatsu-lab/stanford_alpaca. Below is the original copyright:
+#
+#    Copyright 2023 Rohan Taori, Ishaan Gulrajani, Tianyi Zhang, Yann Dubois, Xuechen Li
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from dataclasses import dataclass, field
+import json
+import math
+import pathlib
+from typing import Dict, Optional, Sequence
+
+import wandb
+
+import random
+
+import os
+
+import datasets
+import evaluate
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+import transformers
+from transformers import Trainer
+from transformers.trainer_pt_utils import LabelSmoother
+
+from fastchat.conversation import SeparatorStyle
+from fastchat.model.model_adapter import get_conversation_template
+
+from functools import partial
+
+# local import
+from distill_trainer import DistillTrainer, DistillTrainerCallback
+from distill_trainer_seq2seq import Seq2SeqDistillTrainer, Seq2SeqDistillTrainerCallback
+from load_dataset import load_dataset
+
+IGNORE_TOKEN_ID = LabelSmoother.ignore_index
+
+
+@dataclass
+class ModelArguments:
+    student_model_path: Optional[str] = field(
+        default="facebook/opt-125m",  metadata={"help": "Path to student model"})
+    teacher_model_path: str = field(
+        default=None, metadata={"help": "Path to teacher model"})
+
+
+@dataclass
+class DataArguments:
+    dataset_name: str = field(
+        default=None, metadata={"help": "Dataset's name."}
+    )
+    dataset_config_name: Optional[str] = field(
+        default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
+    )
+    metric: str = field(
+        default='rouge', metadata={"help": "Metric to use for evaluation."}
+    )
+    source_max_length: int = field(
+        default=1024,
+        metadata={
+            "help": "Maximum sequence length for the source. Sequences will be right padded (and possibly truncated)."
+        },
+    )
+    train_target_max_length: int = field(
+        default=64,
+        metadata={
+            "help": "Maximum sequence length for the target during training. Sequences will be right padded."
+        },
+    )
+    val_target_max_length: int = field(
+        default=128,
+        metadata={
+            "help": "Maximum sequence length for the target during validation. Sequences will be right padded."
+        },
+    )
+    test_target_max_length: int = field(
+        default=128,
+        metadata={
+            "help": "Maximum sequence length for the target during testing. Sequences will be right padded."
+        },
+    )
+    max_train_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of training examples to this "
+                "value if set."
+            )
+        },
+    )
+    max_eval_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of evaluation examples to this "
+                "value if set."
+            )
+        },
+    )
+    max_predict_samples: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of prediction examples to this "
+                "value if set."
+            )
+        },
+    )
+    ignore_pad_token_for_loss: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether to ignore the tokens corresponding to padded labels in the loss computation or not."
+        },
+    )
+    num_beams: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Number of beams to use for evaluation. This argument will be passed to ``model.generate``, "
+                "which is used during ``evaluate`` and ``predict``."
+            )
+        },
+    )
+    source_prefix: Optional[str] = field(
+        default="", metadata={"help": "A prefix to add before every source text (useful for T5 models)."}
+    )
+    fast_eval: bool = field(
+        default=True,
+        metadata={"help": "Fast evaluation strategy for logging."}
+    )
+
+
+@dataclass
+class Seq2SeqTrainingArguments(transformers.Seq2SeqTrainingArguments):
+    cache_dir: Optional[str] = field(default=None)
+    optim: str = field(default="adamw_torch")
+    max_propose_num: int = field(
+        default=5,
+        metadata={
+            "help": "gamma, number of tokens the student model proposes for each step."
+        }
+    )
+    mode: str = field(
+        default="offline",
+        metadata={
+            "help": "online mode or offline mode"
+        }
+    )
+    online_eval_interval: int = field(
+        default=10,
+        metadata={
+            "help": "evaluation interval for online training"
+        }
+    )
+    online_update_interval: int = field(
+        default=1,
+        metadata={
+            "help": "parameter update interval for online training"
+        }
+    )
+    sample_source: str = field(
+        default="student",
+        metadata = {
+            "choices" : ["student", "teacher", "mix_request", "mix_token"]
+        }
+    )
+    kl_method: str = field(
+        default="forward",
+        metadata = {
+            "choices" : ["forward", "reverse", "jsd"]
+        }
+    )
+    all_token_mask: bool = field(
+        default=False,
+        metadata = {
+            "help": "meaningful only for online learning. use all tokens to compute loss. otherwise use only wrong tokens"
+        }
+    )
+
+local_rank = None
+
+
+def rank0_print(*args):
+    if local_rank == 0:
+        print(*args)
+
+
+def safe_save_model_for_hf_trainer(trainer: transformers.Trainer, output_dir: str):
+    """Collects the state dict and dump to disk."""
+    state_dict = trainer.model.state_dict()
+    if trainer.args.should_save:
+        cpu_state_dict = {key: value.cpu()
+                          for key, value in state_dict.items()}
+        del state_dict
+        trainer._save(output_dir, state_dict=cpu_state_dict)  # noqa
+
+
+def train():
+    global local_rank
+    
+    parser = transformers.HfArgumentParser(
+        (ModelArguments, DataArguments, Seq2SeqTrainingArguments)
+    )
+    model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+    local_rank = training_args.local_rank
+
+    # Set RoPE scaling factor
+    config = transformers.AutoConfig.from_pretrained(
+        model_args.student_model_path,
+        cache_dir=training_args.cache_dir,
+    )
+    orig_ctx_len = getattr(config, "max_position_embeddings", None)
+    if orig_ctx_len and data_args.source_max_length > orig_ctx_len:
+        scaling_factor = float(
+            math.ceil(data_args.source_max_length / orig_ctx_len))
+        config.rope_scaling = {"type": "linear", "factor": scaling_factor}
+    config.use_cache = False
+
+    # Load model and tokenizer
+    # student model
+    model = transformers.AutoModelForSeq2SeqLM.from_pretrained(
+        model_args.student_model_path,
+        config=config,
+        cache_dir=training_args.cache_dir,
+    )
+    # # train from scratch
+    # model = transformers.LlamaForCausalLM(config)
+
+    # teacher model
+    teacher_config = transformers.AutoConfig.from_pretrained(
+        model_args.teacher_model_path,
+        cache_dir=training_args.cache_dir,
+    )
+    teacher_model = transformers.AutoModelForSeq2SeqLM.from_pretrained(
+        model_args.teacher_model_path,
+        config=teacher_config
+    )
+    teacher_model.cuda()
+
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        model_args.teacher_model_path,
+    )
+    tokenizer.pad_token = tokenizer.unk_token
+
+    training_args.max_source_length = data_args.source_max_length
+    training_args.max_target_length = data_args.train_target_max_length
+    
+    # Load data
+    train_dataset, eval_dataset, predict_dataset = load_dataset(data_args, training_args, tokenizer)
+
+    # Embedding size, start token sanity check
+    # We resize the embeddings only when necessary to avoid index errors. If you are creating a model from scratch
+    # on a small vocab and want a smaller embedding size, remove this test.
+    embedding_size = model.get_input_embeddings().weight.shape[0]
+    if len(tokenizer) > embedding_size:
+        model.resize_token_embeddings(len(tokenizer))
+
+    if model.config.decoder_start_token_id is None:
+        raise ValueError("Make sure that `config.decoder_start_token_id` is correctly defined")
+
+    if (
+        hasattr(model.config, "max_position_embeddings")
+        and model.config.max_position_embeddings < data_args.source_max_length
+    ):
+        if model_args.resize_position_embeddings is None:
+            model.resize_position_embeddings(data_args.msource_max_length)
+        elif model_args.resize_position_embeddings:
+            model.resize_position_embeddings(data_args.source_max_length)
+        else:
+            raise ValueError(
+                f"`--source_max_length` is set to {data_args.source_max_length}, but the model only has"
+                f" {model.config.max_position_embeddings} position encodings. Consider either reducing"
+                f" `--source_max_length` to {model.config.max_position_embeddings} or to automatically resize the"
+                " model's position encodings by passing `--resize_position_embeddings`."
+            )
+
+    training_args.generation_num_beams = (
+        data_args.num_beams if data_args.num_beams is not None else training_args.generation_num_beams
+    )
+
+    # Data collator
+    label_pad_token_id = -100 if data_args.ignore_pad_token_for_loss else tokenizer.pad_token_id
+    data_collator = transformers.DataCollatorForSeq2Seq(
+        tokenizer,
+        model=model,
+        label_pad_token_id=label_pad_token_id,
+        pad_to_multiple_of=8 if training_args.fp16 else None,
+    )
+
+    metric = evaluate.load("rouge")
+    def postprocess_text(preds, labels):
+        preds = [pred.strip() for pred in preds]
+        labels = [label.strip() for label in labels]
+
+        # rougeLSum expects newline after each sentence
+        preds = ["\n".join(nltk.sent_tokenize(pred)) for pred in preds]
+        labels = ["\n".join(nltk.sent_tokenize(label)) for label in labels]
+
+        return preds, labels
+
+    def compute_metrics(eval_preds):
+        preds, labels = eval_preds
+        if isinstance(preds, tuple):
+            preds = preds[0]
+        # Replace -100s used for padding as we can't decode them
+        preds = np.where(preds != -100, preds, tokenizer.pad_token_id)
+        decoded_preds = tokenizer.batch_decode(preds, skip_special_tokens=True)
+        labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+        decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+
+        # Some simple post-processing
+        decoded_preds, decoded_labels = postprocess_text(decoded_preds, decoded_labels)
+
+        result = metric.compute(predictions=decoded_preds, references=decoded_labels, use_stemmer=True)
+        result = {k: round(v * 100, 4) for k, v in result.items()}
+        prediction_lens = [np.count_nonzero(pred != tokenizer.pad_token_id) for pred in preds]
+        result["gen_len"] = np.mean(prediction_lens)
+        return result
+    
+    trainer = Seq2SeqDistillTrainer(
+            model=model, 
+            teacher_model=teacher_model, 
+            tokenizer=tokenizer, 
+            train_dataset=train_dataset if training_args.do_train else None,
+            eval_dataset=eval_dataset if training_args.do_eval else None,
+            data_collator=data_collator,
+            compute_metrics=compute_metrics if training_args.predict_with_generate else None,
+            propose_num=training_args.max_propose_num,
+            args=training_args,
+        )
+    trainer.add_callback(Seq2SeqDistillTrainerCallback)
+
+    if training_args.do_train:
+        if list(pathlib.Path(training_args.output_dir).glob("checkpoint-*")):
+            train_result = trainer.train(resume_from_checkpoint=True)
+        else:
+            train_result = trainer.train()
+        trainer.save_model()
+        metrics = train_result.metrics
+        max_train_samples = (
+            data_args.max_train_samples if data_args.max_train_samples is not None else len(train_dataset)
+        )
+        metrics["train_samples"] = min(max_train_samples, len(train_dataset))
+
+        trainer.log_metrics("train", metrics)
+        trainer.save_metrics("train", metrics)
+        model.config.use_cache = True
+        trainer.save_state()
+
+    # Evaluation
+    results = {}
+    if training_args.do_eval:
+        if isinstance(eval_dataset, dict):
+            metrics = {}
+            for eval_ds_name, eval_ds in eval_dataset.items():
+                dataset_metrics = trainer.evaluate(eval_dataset=eval_ds, metric_key_prefix=f"eval_{eval_ds_name}")
+                metrics.update(dataset_metrics)
+        else:
+            metrics = trainer.evaluate(metric_key_prefix="eval")
+        max_eval_samples = data_args.max_eval_samples if data_args.max_eval_samples is not None else len(eval_dataset)
+        metrics["eval_samples"] = min(max_eval_samples, len(eval_dataset))
+
+        trainer.log_metrics("eval", metrics)
+        trainer.save_metrics("eval", metrics)
+
+    # Testing
+    if training_args.do_predict:
+
+        predict_results = trainer.predict(predict_dataset, metric_key_prefix="predict")
+        metrics = predict_results.metrics
+        max_predict_samples = (
+            data_args.max_predict_samples if data_args.max_predict_samples is not None else len(predict_dataset)
+        )
+        metrics["predict_samples"] = min(max_predict_samples, len(predict_dataset))
+
+        trainer.log_metrics("predict", metrics)
+        trainer.save_metrics("predict", metrics)
+    
+    
+    safe_save_model_for_hf_trainer(
+        trainer=trainer, output_dir=training_args.output_dir)
+
+
+if __name__ == "__main__":
+    train()


### PR DESCRIPTION
Added data cleaning and prompting support on T5 for:
1. machine translation benchmark: WMT16.
2. summarization benchmarks: cnn_dailymail, xsum, wikihow.
3. math benchmark: GSM8K.
4. spec-to-code generation: spider, python.
5. QA benchmark: finance-alpaca.

small experiments:
T5 generator correctness check in `test_t5.py` with a selection of different input prompts.
T5 speculative coding effecitveness check in `compare_model_t5.py` with successive rate 
 calculated.

To run offline distillation for FLAN-T5-XL to T5-small (on the spider benchmark):

> `bash bash_scripts/t5/online.sh {your_datapath} spider teacher forward 2 8`

To run online distillation for FLAN-T5-XL to T5-small (on the spider benchmark):

> `bash bash_scripts/t5/online.sh {your_datapath} spider teacher forward 2`
