### PR TITLE
draft for # TODO: we can avoid this forward by getting logits during speculative decoding

### DIFF
--- a/distill/train.py
+++ b/distill/train.py
@@ -97,6 +97,12 @@ class TrainingArguments(transformers.TrainingArguments):
             "choices" : ["forward", "reverse", "jsd"]
         }
     )
+    recompute_logits: bool = field(
+        default=False,
+        metadata = {
+            "help" : "recompute logits for distillation"
+        }
+    )
 
 
 local_rank = None


### PR DESCRIPTION
Code changes to collect logits of tokens accepted by the teacher model during speculative decoding.
Can potentially be further simplified by changing the cross-entropy code.
The logits do not seem to exactly match the logits produced with the old code, with differences being observed up in the 1e-3 range.